### PR TITLE
Change depcrecated string-type addition

### DIFF
--- a/src/parse.typ
+++ b/src/parse.typ
@@ -24,7 +24,7 @@
     assert(type(supplement) in (content, str))
     assert(
       type(col) in (color, type(auto)),
-      message: "Please provide a color as second arguments: " + supplement + " (was " + type(col) + ")",
+      message: "Please provide a color as second arguments: " + supplement + " (was " + repr(type(col)) + ")",
     )
     ((id, supplement, col),)
   }


### PR DESCRIPTION
Adding types to strings is deprecated, and will be removed in Typst 0.14. Instead, the code now converts the type to a string first