### PR TITLE
fix(api): handle `none` as figure numbering

### DIFF
--- a/src/bundled-layout.typ
+++ b/src/bundled-layout.typ
@@ -52,7 +52,9 @@
     // We use the caption because we have access to the supplement and the numbering there.
     show figure.caption.where(body: caption-id): caption => (
       context {
-        let number = caption.counter.display(caption.numbering)
+        let number = if caption.numbering != none {
+          caption.counter.display(caption.numbering)
+        }
         style(title, tags, body, supplement, number, custom-arg)
       }
     )

--- a/src/layout.typ
+++ b/src/layout.typ
@@ -45,7 +45,9 @@
     if not code-has-info-attached(code) or retrieve-info-from-code(code).kind != kind {
       caption
     } else {
-      let number = context caption.counter.display(caption.numbering)
+      let number = if caption.numbering != none {
+        context caption.counter.display(caption.numbering)
+      }
       let (
         title,
         tags,


### PR DESCRIPTION
Hi. I noticed that figure numbering is not properly handled in https://forum.typst.app/t/frame-it-how-to-remove-counter-from-frame/6509/3?u=andrew.
